### PR TITLE
Update SceneComponent.js

### DIFF
--- a/SceneComponent.js
+++ b/SceneComponent.js
@@ -6,7 +6,7 @@ const {View, StyleSheet, } = ReactNative;
 const StaticContainer = require('./StaticContainer');
 
 const SceneComponent = (Props) => {
-  const {shouldUpdated, ...props, } = Props;
+  const {shouldUpdated, ...props } = Props;
   return <View {...props}>
       <StaticContainer shouldUpdate={shouldUpdated}>
         {props.children}


### PR DESCRIPTION
Trailing comma after rest creates an error in newer versions of React-Native. See https://github.com/ptomasroos/react-native-scrollable-tab-view/issues/910